### PR TITLE
在容器启动时自动更新 lab 数据

### DIFF
--- a/bin/deploy-lims2
+++ b/bin/deploy-lims2
@@ -30,6 +30,7 @@ then
 fi
 
 : ${LIMS2_DIR:="$TARGET_DIR/lims2"}
+: ${LAB_DIR:="$TARGET_DIR/lib"}
 : ${MYSQL_DIR:="$TARGET_DIR/mysql"}
 : ${SPHINX_DIR:="$TARGET_DIR/sphinxsearch"}
 
@@ -89,9 +90,16 @@ then
 	fi
 fi
 
+: ${BACKUP_LAB_DIR:=${LIMS2_DIR}/sites/${SITE_ID}/labs/${LAB_ID}}
+BACKUP_LAB_DIR=${BACKUP_LAB_DIR%%/}
+rsync -azKs "${BACKUP_LAB_DIR}/" "${LAB_DIR}"
+rm -rf $LIMS2_DIR/sites/lab
+DOCKER_LAB_DIR="/var/lib/lims2/sites/${SITE_ID}/labs/${LAB_ID}"
+ln -s "$DOCKER_LAB_DIR" $LIMS2_DIR/sites/lab
 docker run --name $CONTAINER_NAME -v /dev/log:/dev/log -v $TARGET_DIR:/data --privileged \
     -v $NGINX_CONFIG_DIR:/etc/nginx/sites-enabled \
     -v $NGINX_LOG_DIR:/var/log/nginx \
     -v $LIMS2_DIR:/usr/local/share/lims2 \
+    -v $LAB_DIR:$DOCKER_LAB_DIR \
     -p 80 \
     -d iamfat/lims2


### PR DESCRIPTION
在配置文件中增加两个变量：
# LAB_DIR

LAB_DIR 是 /var/lib/lims2/sites/SITE_ID/labs/LAB_ID/ 在宿主机上对应的位置
# BACKUP_LAB_DIR

从线上获取的 LAB_DIR 的备份。如果未定义，则会将 lims2 的源代码中的模板复制到 LAB_DIR
