### PR TITLE
Redirecting with original port.

### DIFF
--- a/template/config/sites/lims2
+++ b/template/config/sites/lims2
@@ -7,7 +7,11 @@ server {
     root /usr/share/nginx/html;
     index index.php index.html index.htm;
 
-    location /lims {
+    location = /lims {
+        return 301 lims/;
+    }
+
+    location /lims/ {
         alias /usr/share/lims2/public/;
 
         location ~ ^/lims/\!.+\.(js|css|png|jpg|jpeg|gif|ico|swf)$ {


### PR DESCRIPTION
Redirect `http://IP:PORT/lims` to `http://IP:PORT/lims/` instead of `http://IP/lims/`.
